### PR TITLE
TRITON-XXXX Preserve internal_metadata_namespaces when migrating VMs.

### DIFF
--- a/lib/workflows/provision.js
+++ b/lib/workflows/provision.js
@@ -6,6 +6,7 @@
 
 /*
  * Copyright 2020 Joyent, Inc.
+ * Copyright 2024 Spearhead Systems SRL.
  */
 
 /*
@@ -159,7 +160,8 @@ function preparePayload(job, cb) {
         'delegate_dataset', 'dns_domain', 'docker', 'do_not_inventory',
         'firewall_enabled', 'firewall_rules', 'fs_allowed',
         'hostname', 'indestructible_zoneroot', 'indestructible_delegated',
-        'init_name', 'internal_metadata', 'kernel_version', 'limit_priv',
+        'init_name', 'internal_metadata', 'internal_metadata_namespaces',
+        'kernel_version', 'limit_priv',
         'maintain_resolvers', 'max_locked_memory', 'max_lwps', 'max_msg_ids',
         'max_physical_memory', 'max_shm_memory', 'max_sem_ids', 'max_shm_ids',
         'max_swap', 'mdata_exec_timeout', 'nics',


### PR DESCRIPTION
If a VM is using `internal_metadata_namespaces`, and is then migrated, the `internal_metadata_namespaces` field is lost. Hilarity ensues.

Example VM before transfer:

```
[root@e4-43-4b-86-72-c8 (ro-1) ~]# vmadm get 486b163c-81a1-4dba-b22e-5315f3943242 | json internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
[
  "foo"
]
```

Example VM metadata in VMAPI before transfer:

```
[root@headnode (ro-1) ~]# sdc-vmapi /vms/486b163c-81a1-4dba-b22e-5315f3943242 | json -H internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
[
  "foo"
]
```

Performing the transfer:

```
[root@headnode (ro-1) ~]# sdc-migrate migrate -n 44454c4c-4400-105a-8037-c3c04f513033 486b163c-81a1-4dba-b22e-5315f3943242
# Migration begin running in job 6e583311-07bf-4da9-a1cc-60f624c4e8a3
 - reserving instance
 - syncing data
 - syncing data
  - running: 100%  1.1kB/s  (ETA 4s)
 - stopping the instance
 - syncing data
 - switching instances
 - filesytem sync finished, switching instances
 - reserving the IP addresses for the instance
 - setting up the target filesystem
 - hiding the original instance
 - promoting the migrated instance
 - removing sync snapshots
OK - switch was successful
```

Example VM after transfer:

```
[root@24-6e-96-2e-fa-54 (ro-1) ~]# vmadm get 486b163c-81a1-4dba-b22e-5315f3943242 | json internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
```

Example VM metadata in VMAPI after transfer:

```
[root@headnode (ro-1) ~]# sdc-vmapi /vms/486b163c-81a1-4dba-b22e-5315f3943242 | json -H internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
```

--------

After this patch, the sdc-migration (in this case back to e4-43-4b-86-72-c8) preserves `internal_metadata_namespaces`:

```
[root@e4-43-4b-86-72-c8 (ro-1) ~]# vmadm get 486b163c-81a1-4dba-b22e-5315f3943242 | json internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
[
  "foo"
]
```
```
[root@headnode (ro-1) ~]# sdc-vmapi /vms/486b163c-81a1-4dba-b22e-5315f3943242 | json -H internal_metadata internal_metadata_namespaces
{
  "foo:bar": "baz"
}
[
  "foo"
]
```